### PR TITLE
fix(testing): avoid null error in content-type

### DIFF
--- a/include-in-tests/autoMockCommands.js
+++ b/include-in-tests/autoMockCommands.js
@@ -171,7 +171,7 @@ function registerAutoMockCommands() {
 
               function recordTransformedObject(xhr, requestObject, responseObject) {
                 let contentType = xhr.getResponseHeader('content-type');
-                if (contentType.toLowerCase().indexOf('application/json') !== -1) {
+                if (contentType !== null && contentType.toLowerCase().indexOf('application/json') !== -1) {
                   try {
                     responseObject = JSON.parse(responseObject);
                   } catch (e) {}


### PR DESCRIPTION
When API do not include contentType header to response, then function toLowerCase() fails because
contentType is null